### PR TITLE
Add `fmt` trait impls for heap containers

### DIFF
--- a/src/containers.rs
+++ b/src/containers.rs
@@ -1,10 +1,11 @@
 use crate::node::{Active, ActiveArr};
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
-use core::ptr::{drop_in_place, addr_of};
+use core::ptr::{addr_of, drop_in_place};
 use core::slice::{from_raw_parts, from_raw_parts_mut};
-use core::sync::atomic::{Ordering, AtomicUsize};
+use core::sync::atomic::{AtomicUsize, Ordering};
 use core::{
+    fmt,
     mem::forget,
     ops::{Deref, DerefMut},
     ptr::NonNull,
@@ -132,6 +133,27 @@ impl<T> Clone for HeapArc<T> {
     }
 }
 
+impl<T: fmt::Display> fmt::Display for HeapArc<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for HeapArc<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<T> fmt::Pointer for HeapArc<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Pointer::fmt(&self.ptr, f)
+    }
+}
+
 // === impl HeapArray ===
 
 unsafe impl<T> Send for HeapArray<T> {}
@@ -184,6 +206,23 @@ impl<T> Drop for HeapArray<T> {
     }
 }
 
+impl<T> fmt::Debug for HeapArray<T>
+where
+    [T]: fmt::Debug,
+{
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<T> fmt::Pointer for HeapArray<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Pointer::fmt(&self.ptr, f)
+    }
+}
+
 // === impl HeapFixedVec ===
 
 unsafe impl<T> Send for HeapFixedVec<T> {}
@@ -232,5 +271,22 @@ impl<T> Drop for HeapFixedVec<T> {
             }
             ActiveArr::<MaybeUninit<T>>::yeet(self.ptr);
         }
+    }
+}
+
+impl<T> fmt::Debug for HeapFixedVec<T>
+where
+    [T]: fmt::Debug,
+{
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<T> fmt::Pointer for HeapFixedVec<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Pointer::fmt(&self.ptr, f)
     }
 }


### PR DESCRIPTION
This branch adds `fmt::Debug`, `fmt::Display`, and `fmt::Pointer` impls
to `HeapArc`, `HeapArray`, and `HeapFixedVec`, as appropriate. The
`Display` and `Debug` impls forward to the inner types, and require
`T: fmt::Debug` or `T: fmt::Display`; on the other hand, the
`fmt::Pointer` impls are always present regardless of `T` and display
the address of the heap allocation.

I wanted the `fmt::Pointer` impls specifically for tosc-rs/mnemos#4, so
that the bbqueue traces could include the address of the shared buffer,
but they didn't exist at the time, so I thought they would be nice to
add.