### PR TITLE
containers: fix missing and wrong `Send` + `Sync` impls

### DIFF
--- a/src/containers.rs
+++ b/src/containers.rs
@@ -42,7 +42,8 @@ pub struct HeapFixedVec<T> {
 
 // === impl HeapBox ===
 
-unsafe impl<T> Send for HeapBox<T> {}
+unsafe impl<T: Send> Send for HeapBox<T> {}
+unsafe impl<T: Sync> Sync for HeapBox<T> {}
 
 impl<T> Deref for HeapBox<T> {
     type Target = T;
@@ -86,7 +87,10 @@ impl<T> Drop for HeapBox<T> {
 
 // === impl HeapArc ===
 
-unsafe impl<T> Send for HeapArc<T> {}
+// These require the same bounds as `alloc::sync::Arc`'s `Send` and `Sync`
+// impls.
+unsafe impl<T: Send + Sync> Send for HeapArc<T> {}
+unsafe impl<T: Send + Sync> Sync for HeapArc<T> {}
 
 impl<T> Deref for HeapArc<T> {
     type Target = T;
@@ -156,7 +160,8 @@ impl<T> fmt::Pointer for HeapArc<T> {
 
 // === impl HeapArray ===
 
-unsafe impl<T> Send for HeapArray<T> {}
+unsafe impl<T: Send> Send for HeapArray<T> {}
+unsafe impl<T: Sync> Sync for HeapArray<T> {}
 
 impl<T> Deref for HeapArray<T> {
     type Target = [T];
@@ -225,7 +230,8 @@ impl<T> fmt::Pointer for HeapArray<T> {
 
 // === impl HeapFixedVec ===
 
-unsafe impl<T> Send for HeapFixedVec<T> {}
+unsafe impl<T: Send> Send for HeapFixedVec<T> {}
+unsafe impl<T: Sync> Sync for HeapFixedVec<T> {}
 
 impl<T> Deref for HeapFixedVec<T> {
     type Target = [T];


### PR DESCRIPTION
This commit fixes some implementations of `Send` and `Sync` for the
`HeapFoo` container types that were either wrong or missing. In
particular:

- No heap container types currently implement `Sync`. This is
  unfortunate when trying to spawn Tokio tasks in `melpomene`, since
  tasks must be `Send + Sync` to be spawned. I've added `Sync` impls for
  all the heap types.
- The `Send` implementations for `HeapBox`, `HeapArray`, and
  `HeapFixedVec` do not require that `T: Send`. This is incorrect;
  sending a `HeapBox<T>` where `T: !Send` is functionally equivalent to
  sending a `T`. Note that (for ereference) `alloc::boxed::Box`'s `Send`
  impl [requires `T: Send`][1].
- The `Send` and `Sync` impls for `HeapArc<T>` both require
  `T: Send + Sync`, since sending an `Arc<T>` across threads is morally
  equivalent to sending an `&T`. Again, these are the same bounds as the
  `Send` and `Sync` [impls for `alloc::sync::Arc`][2].

[1]:
    https://doc.rust-lang.org/stable/alloc/boxed/struct.Box.html#impl-Send

[2]:
    https://doc.rust-lang.org/stable/alloc/sync/struct.Arc.html#impl-Send