### PR TITLE
add `Heap::allocate_raw` and `deallocate_raw`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ default-features = false
 
 [patch.crates-io.maitake]
 git = "https://github.com/hawkw/mycelium.git"
-rev = "23db951d19cf410e07ed4c2c47ead20d2b592d21"
+rev = "5e46e35cae131d5f60f527e6659dc53b18e30ebb"
 
 [patch.crates-io.cordyceps]
 git = "https://github.com/hawkw/mycelium.git"
-rev = "23db951d19cf410e07ed4c2c47ead20d2b592d21"
+rev = "5e46e35cae131d5f60f527e6659dc53b18e30ebb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ default-features = false
 
 [patch.crates-io.maitake]
 git = "https://github.com/hawkw/mycelium.git"
-rev = "5e46e35cae131d5f60f527e6659dc53b18e30ebb"
+rev = "23db951d19cf410e07ed4c2c47ead20d2b592d21"
 
 [patch.crates-io.cordyceps]
 git = "https://github.com/hawkw/mycelium.git"
-rev = "5e46e35cae131d5f60f527e6659dc53b18e30ebb"
+rev = "23db951d19cf410e07ed4c2c47ead20d2b592d21"

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -15,7 +15,7 @@ use crate::{
 
 use cordyceps::mpsc_queue::{Links, MpscQueue};
 use linked_list_allocator::Heap;
-use maitake::wait::WaitQueue;
+use maitake::sync::WaitQueue;
 
 /// An Anachro Heap item
 pub struct AHeap {

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -10,7 +10,7 @@ use core::{
 
 use crate::{
     containers::{HeapArray, HeapBox, ArcInner, HeapArc, HeapFixedVec},
-    node::{self, Active, ActiveArr, Node, NodeRef, Recycle, ActiveUnsized},
+    node::{Active, ActiveArr, Node, NodeRef, Recycle, ActiveUnsized},
 };
 
 use cordyceps::mpsc_queue::{Links, MpscQueue};

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -15,7 +15,7 @@ use crate::{
 
 use cordyceps::mpsc_queue::{Links, MpscQueue};
 use linked_list_allocator::Heap;
-use maitake::sync::WaitQueue;
+use maitake::wait::WaitQueue;
 
 /// An Anachro Heap item
 pub struct AHeap {

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -10,7 +10,7 @@ use core::{
 
 use crate::{
     containers::{HeapArray, HeapBox, ArcInner, HeapArc, HeapFixedVec},
-    node::{Active, ActiveArr, Node, NodeRef, Recycle},
+    node::{self, Active, ActiveArr, Node, NodeRef, Recycle, ActiveUnsized},
 };
 
 use cordyceps::mpsc_queue::{Links, MpscQueue};
@@ -275,6 +275,45 @@ impl AHeap {
             self.heap_wait.wait().await.unwrap();
         }
     }
+
+    pub async fn allocate_raw(&'static self, layout: Layout) -> NonNull<()> {
+        loop {
+            // Is the heap inhibited?
+            if !self.inhibit_alloc.load(Ordering::Acquire) {
+                // Can we get an exclusive heap handle?
+                if let Ok(mut hg) = self.lock() {
+                    match hg.alloc_raw(layout) {
+                        Ok(hb) => {
+                            // Yes! Return our allocated item
+                            return hb;
+                        }
+                        Err(_) => {
+                            // Nope, the allocation failed.
+                        }
+                    }
+                }
+                // We weren't inhibited before, but something failed. Inhibit
+                // further allocations to prevent starving waiting allocations
+                self.inhibit_alloc.store(true, Ordering::Release);
+            }
+
+            // Didn't succeed, wait until we've done some de-allocations
+            self.heap_wait.wait().await.unwrap();
+        }
+    }
+} 
+
+/// Deallocate an unsized allocation with the provided `Layout`.
+///
+/// # Safety
+///
+/// - `ptr` *must* have been returned by a call to [`Heap::allocate_raw`] or
+///   [`HeapGuard::alloc_raw`]!
+/// - `layout` *must* be the same `Layout` that was provided to the original
+///   call to [`Heap::allocate_raw`] or[`HeapGuard::alloc_raw`]!
+pub unsafe fn deallocate_raw(ptr: NonNull<()>, layout: Layout) {
+    let ptr = ActiveUnsized::from_raw(ptr);
+    ActiveUnsized::yeet(ptr, layout);
 }
 
 /// A guard type that provides mutually exclusive access to the allocator as
@@ -432,6 +471,24 @@ impl HeapGuard {
             pd: PhantomData,
             len: 0,
         })
+    }
+
+    pub fn alloc_raw(&mut self, layout: Layout) -> Result<NonNull<()>, ()> {
+        // Clean up any pending allocs
+        self.clean_allocs();
+
+        // calculate the layout of the requested allocation
+        let layout = ActiveUnsized::layout(layout);
+
+        // Then, attempt to allocate the requested T.
+        let nnu8 = self.get_heap().allocate_first_fit(layout)?;
+        let ptr = nnu8.cast::<ActiveUnsized>();
+
+        unsafe {
+            ActiveUnsized::write_heap(ptr, self.aheap);
+
+            Ok(ActiveUnsized::data(ptr))
+        }
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -88,6 +88,16 @@ pub(crate) struct ActiveArr<T> {
     data: [T; 0],
 }
 
+#[repr(C)]
+pub(crate) struct ActiveUnsized {
+    heap: *const AHeap,
+    // NOTE(eliza): we *could* make this know its own layout, too, if we wanted
+    // to...that would give us an `ActiveUnsized::deallocate` function that
+    // doesn't need a user-provided layout. But I didn't do that, because I
+    // didn't actually need it right now.
+    data: [u8; 0],
+}
+
 /// A Recycle node type
 ///
 /// Recycle is the "terminal state" of all allocations. After the actual
@@ -242,6 +252,83 @@ impl<T> ActiveArr<T> {
 
         (*heap).release_node(ptr);
     }
+}
+
+impl ActiveUnsized {
+    /// Obtain a valid layout for an ActiveUnsized with an inner allocation of
+    /// the requested `Layout`.
+    #[inline]
+    pub(crate) fn layout(layout_inner: Layout) -> Layout {
+        let layout_node = Layout::new::<Node<()>>();
+        let (mut layout, _offset) = Layout::new::<*const AHeap>().extend(layout_inner).unwrap();
+        debug_assert_eq!(_offset as isize, Self::data_offset(), "this is real bad!");
+        // round up to ensure we can fit a `Node`
+        if layout_node.size() > layout.size() {
+            layout = layout_node;
+        }
+        layout
+    }
+
+    /// Set the heap pointer contained within the given `ActiveUnsized`.
+    ///
+    /// This should ONLY be used to initialize the `ActiveUnsized` at time of allocation.
+    #[inline(always)]
+    pub(crate) unsafe fn write_heap(this: NonNull<Self>, heap: *const AHeap) {
+        let ptr = this.as_ptr();
+        core::ptr::addr_of_mut!((*ptr).heap).write(heap);
+    }
+
+
+    /// Obtain a pointer to the start of the unsized storage,
+    #[inline(always)]
+    pub(crate) unsafe fn data(this: NonNull<Self>) -> NonNull<()> {
+        let tptr = this.as_ptr();
+        let daddr = core::ptr::addr_of_mut!((*tptr).data);
+        NonNull::new_unchecked(daddr.cast::<()>())
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn from_raw(data: NonNull<()>) -> NonNull<Self> {
+        let ptr = data
+            .cast::<u8>()
+            .as_ptr()
+            .offset(Self::data_offset())
+            .cast::<Self>();
+        NonNull::new_unchecked(ptr)
+    }
+
+    #[inline(always)]
+    fn data_offset() -> isize {
+        let dummy: ActiveUnsized = ActiveUnsized {
+            heap: null(),
+            data: [],
+        };
+        let data_ptr = addr_of!(dummy.data);
+        let dummy_ptr: *const ActiveUnsized = &dummy;
+        unsafe { dummy_ptr.cast::<u8>().offset_from(data_ptr.cast::<u8>()) }
+    }
+
+    /// Convert an `ActiveUnsized` into a Recycle, and release it to be freed.
+    ///
+    /// # Safety
+    ///
+    /// The provided `Layout` *must* be the same as the `ActiveUnsized`'s
+    /// original allocated `Layout`!
+    #[inline]
+    pub(crate) unsafe fn yeet(mut ptr: NonNull<Self>, layout: Layout) {
+        let heap = ptr.as_mut().heap;
+
+        let ptr: NonNull<Recycle> = ptr.cast();
+        let layout = Self::layout(layout);
+
+        ptr.as_ptr().write(Recycle {
+            links: Links::new(),
+            node_layout: layout,
+        });
+
+        (*heap).release_node(ptr);
+    }
+
 }
 
 impl<T> Drop for Node<T> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -261,7 +261,7 @@ impl ActiveUnsized {
     pub(crate) fn layout(layout_inner: Layout) -> Layout {
         let layout_node = Layout::new::<Node<()>>();
         let (mut layout, _offset) = Layout::new::<*const AHeap>().extend(layout_inner).unwrap();
-        debug_assert_eq!(_offset as isize, Self::data_offset(), "this is real bad!");
+        debug_assert_eq!(0 - _offset as isize, Self::data_offset(), "this is real bad!");
         // round up to ensure we can fit a `Node`
         if layout_node.size() > layout.size() {
             layout = layout_node;

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,5 +1,5 @@
-use std::ops::Deref;
-use std::ptr::NonNull;
+use std::{ops::Deref, alloc::Layout};
+use std::ptr::{NonNull, addr_of_mut};
 
 use mnemos_alloc::{
     containers::{HeapArray, HeapBox},
@@ -51,6 +51,57 @@ fn basic_arr() {
 
     let alloc_1: HeapArray<u16> = guard.alloc_box_array_with(|| 0xACAC, 42).unwrap();
     let alloc_2: HeapArray<u16> = guard.alloc_box_array_with(|| 0x4242, 27).unwrap();
+
+    drop(alloc_1);
+    drop(guard);
+    drop(alloc_2);
+}
+
+#[test]
+fn basic_raw() {
+    const SIZE: usize = 16 * 1024;
+
+    const ALLOC_1_F64S: usize = 12;
+    const ALLOC_2_U64S: usize = 17;
+
+    let bufptr = Box::into_raw(Box::new([0u8; SIZE]));
+    let (_heap, mut guard) = unsafe { AHeap::bootstrap(bufptr.cast::<u8>(), SIZE).unwrap() };
+
+    #[repr(C)]
+    struct Tail {
+        a: u8,
+        b: u128,
+        c: [u64; 0]
+    }
+
+    let layout_1 = Layout::array::<f64>(ALLOC_1_F64S).unwrap();
+    let (layout_2, _) = Layout::new::<Tail>().extend(Layout::array::<u64>(ALLOC_2_U64S).unwrap()).unwrap();
+
+    let alloc_1: NonNull<()> = guard.alloc_raw(layout_1).unwrap();
+    let alloc_2: NonNull<()> = guard.alloc_raw(layout_2).unwrap();
+
+    // Write the full contents of alloc 1
+    for i in 0..ALLOC_1_F64S {
+        unsafe {
+            alloc_1.cast::<f64>().as_ptr().add(i).write(1.2345f64);
+        }
+    }
+    // read it back
+    let sli = unsafe { core::slice::from_raw_parts(alloc_1.cast::<f64>().as_ptr(), ALLOC_1_F64S) };
+    assert!(sli.iter().all(|f| *f == 1.2345f64));
+
+    // Write the full contents of alloc 2
+    unsafe {
+        let ptr2 = alloc_2.cast::<Tail>().as_ptr();
+        addr_of_mut!((*ptr2).a).write(10);
+        addr_of_mut!((*ptr2).b).write(u128::MAX - 3);
+        let base = addr_of_mut!((*ptr2).c).cast::<u64>();
+        for i in 0..ALLOC_2_U64S {
+            base.add(i).write(u64::MAX - (i as u64));
+        }
+        let sli = core::slice::from_raw_parts(base, ALLOC_2_U64S);
+        assert!(sli.iter().enumerate().all(|(i, u)| *u == (u64::MAX - i as u64)));
+    }
 
     drop(alloc_1);
     drop(guard);


### PR DESCRIPTION
This branch adds new APIs for lower-level manual memory management. The `Heap::allocate_raw` method takes a user-provided `Layout` and allocates an unsized, untyped allocation for that layout. The `unsafe` free function `deallocate_raw` deallocates a pointer and `Layout` pair that were allocated by `allocate_raw`. Together, these (unsafe) APIs allow the implementation of user-defined types which manually manage a dynamically-sized allocation, which was not previously possible with `mnemos-alloc`.

Closes #4

Note that unlike the proposed interface in #4, this does *not* allow a `HeapBox` to own a `!Sized` type. I'd like to figure that out eventually, but it's somewhat orthogonal to the central concern of "how do I allocate a raw `Layout`?