### PR TITLE
update `mycelium` deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ default-features = false
 
 [patch.crates-io.maitake]
 git = "https://github.com/hawkw/mycelium.git"
-rev = "23db951d19cf410e07ed4c2c47ead20d2b592d21"
+rev = "5e46e35cae131d5f60f527e6659dc53b18e30ebb"
 
 [patch.crates-io.cordyceps]
 git = "https://github.com/hawkw/mycelium.git"
-rev = "23db951d19cf410e07ed4c2c47ead20d2b592d21"
+rev = "5e46e35cae131d5f60f527e6659dc53b18e30ebb"

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -15,7 +15,7 @@ use crate::{
 
 use cordyceps::mpsc_queue::{Links, MpscQueue};
 use linked_list_allocator::Heap;
-use maitake::wait::WaitQueue;
+use maitake::sync::WaitQueue;
 
 /// An Anachro Heap item
 pub struct AHeap {


### PR DESCRIPTION
This branch updates the `cordyceps` and `maitake` dependencies to hawkw/mycelium@5e46e35cae131d5f60f527e6659dc53b18e30ebb.

This shouldn't merge until tosc-rs/mnemos#45 has been merged
with the SHA for `mnemos-alloc` pinned to a commit that includes
the unsized allocator change.