### PR TITLE
add missing `Send` impl for `AHeap`

### DIFF
--- a/src/heap.rs
+++ b/src/heap.rs
@@ -31,6 +31,7 @@ pub struct AHeap {
 // atomic operations to ensure the data is initialized and exclusively
 // accessed.
 unsafe impl Sync for AHeap {}
+unsafe impl Send for AHeap {}
 
 impl AHeap {
     /// The AHeap is initialized, and no `HeapGuard`s are active.

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -146,3 +146,17 @@ fn leak_unleak() {
         }
     );
 }
+
+
+#[test]
+fn allocating_futures_are_send() {
+    const SIZE: usize = 16 * 1024;
+    fn assert_send<T: Send>(_t: T) {}
+
+    let bufptr = Box::into_raw(Box::new([0u8; SIZE]));
+    let (heap, mut guard) = unsafe { AHeap::bootstrap(bufptr.cast::<u8>(), SIZE).unwrap() };
+    let heap = unsafe { heap.as_ref() };
+    assert_send(heap.allocate_arc(1));
+    assert_send(heap.allocate_array_with(|| 1, 1));
+    assert_send(heap.allocate(1));
+}


### PR DESCRIPTION
Currently, any `Future` that awaits one of the `AHeap` `allocate`,
`allocate_arc`, `allocate_array_with`, or `allocate_fixed_vec` methods
is `!Send`. This is because these methods return a `Future` which
contains a `&self` receiver, and the `AHeap` type itself is `!Send`.
This is sad and not very great.

This branch adds a missing `Send` impl to `AHeap`. This should be safe
for the same reason that the existing `unsafe impl Sync for AHeap` is
safe.